### PR TITLE
Monkeypatch pytest assert comparison order to expected == actual

### DIFF
--- a/expyct/__init__.py
+++ b/expyct/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 
+from ._patch import patch_pytest_assert_comp_order
 from .any import Any, AnyValue, AnyType, ANY, ANY_VALUE, ANY_TYPE
 from .base import MapBefore, Satisfies, Instance, Type, Equals, Vars, Optional
 from .collection import Collection, Length, List, Tuple, Set, Dict

--- a/expyct/_patch.py
+++ b/expyct/_patch.py
@@ -1,0 +1,50 @@
+import ast
+from functools import wraps
+from typing import List, Mapping, Type
+
+
+def patch_pytest_assert_comp_order():
+    """
+    Monkeypatches pytest's assertion rewriting logic by switching around the left and right
+    operands of the comparison. This is needed because pytest (and IDEs) assumes the order to
+    be `actual == expected`, but Expyct works better with `expected == actual` because then
+    the `__eq__` method of the left Expyct objects get called.
+    """
+
+    import _pytest.assertion
+
+    def invert_operator(op: ast.cmpop) -> ast.cmpop:
+        mapping: Mapping[Type[ast.cmpop], ast.cmpop] = {
+            ast.Lt: ast.Gt(),
+            ast.LtE: ast.GtE(),
+            ast.Gt: ast.Lt(),
+            ast.GtE: ast.LtE(),
+        }
+        return mapping.get(type(op), op)
+
+    def swap_compare(compare: ast.Compare) -> ast.Compare:
+        # Swap left and right sides of comparison
+        compare.left, compare.comparators[0] = compare.comparators[0], compare.left
+        # Invert asymmetric operators <, <=, >, >=
+        compare.ops[0] = invert_operator(compare.ops[0])
+        return compare
+
+    orig_visit_Assert = _pytest.assertion.rewrite.AssertionRewriter.visit_Assert
+
+    @wraps(orig_visit_Assert)
+    def new_visit_Assert(self, assert_: ast.Assert) -> List[ast.stmt]:
+        stmts = orig_visit_Assert(self, assert_)
+        try:
+            i_compare = next(
+                (i, stm)
+                for i, stm in enumerate(stmts)
+                if isinstance(stm, ast.Assign) and isinstance(stm.value, ast.Compare)
+            )[0]
+        except StopIteration:
+            pass
+        else:
+            # Only the comparison is swapped. The output added by pytest is not changed
+            stmts[i_compare].value = swap_compare(stmts[i_compare].value)
+        return stmts
+
+    _pytest.assertion.rewrite.AssertionRewriter.visit_Assert = new_visit_Assert

--- a/expyct/any.py
+++ b/expyct/any.py
@@ -1,4 +1,5 @@
 import typing
+
 from dataclasses import dataclass
 
 from expyct.base import MapBefore, Satisfies, Instance, Type, Equals, Vars, Optional
@@ -49,7 +50,14 @@ class Any(Satisfies, Vars, Equals[typing.Any], Optional, MapBefore):
 
 
 @dataclass
-class AnyValue(Instance, Satisfies, Vars, Equals[typing.Any], Optional, MapBefore):
+class AnyValue(
+    Instance,
+    Satisfies,
+    Vars,
+    Equals[typing.Any],
+    Optional,
+    MapBefore,
+):
     """Match any value."""
 
     def __init__(

--- a/expyct/base.py
+++ b/expyct/base.py
@@ -1,6 +1,7 @@
 import abc
 import inspect
 import typing
+
 from dataclasses import dataclass
 
 T = typing.TypeVar("T")

--- a/expyct/collection.py
+++ b/expyct/collection.py
@@ -243,7 +243,7 @@ class List(Satisfies, Contains, Length, Equals[list], Optional, MapBefore, AllOr
         satisfies: typing.Optional[typing.Callable[[typing.Any], bool]] = None,
         ignore_order: bool = False,
     ):
-        """ "Match any object that is an instance of `list`.
+        """Match any object that is an instance of `list`.
 
         Args:
             all : all members of collection must equal

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+from expyct import patch_pytest_assert_comp_order
+
+patch_pytest_assert_comp_order()


### PR DESCRIPTION
This PR adds the `patch_pytest_assert_comp_order` function that can be used to swap the order of `assert actual == expected` to `assert expected == actual` (which is better for Expyct), automatically for all test files.