### PR TITLE
Add type and instance_of methods parameters to Any class

### DIFF
--- a/expyct/__version__.py
+++ b/expyct/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "1.0.0"
+VERSION = "1.0.1"

--- a/expyct/base.py
+++ b/expyct/base.py
@@ -1,5 +1,4 @@
 import abc
-import inspect
 import typing
 
 from dataclasses import dataclass
@@ -169,19 +168,27 @@ class Instance(BaseMatcher):
         self.instance_of = instance_of
 
     def _eq(self, other):
-        # TODO check
-        if (
-            inspect.ismodule(other)
-            or inspect.isclass(other)
-            or inspect.isfunction(other)
-            or inspect.ismethod(other)
-        ):
-            return False
         if self.type and type(other) != self.type:
             return False
         if self.instance_of and not isinstance(other, self.instance_of):
             return False
         return True
+
+    @property  # type: ignore
+    def __class__(self):
+        """
+        Allows Instance objects to pretend to be an instance of another class.
+
+        For example:
+            `isinstance(Instance(type=float), float)` is true
+
+        This is needed for type-checking libraries like mypy.
+        """
+
+        fake_class = self.type or self.instance_of
+        if fake_class:
+            return fake_class
+        return type(self)
 
 
 @dataclass(repr=False, eq=False)

--- a/tests/test_any.py
+++ b/tests/test_any.py
@@ -39,6 +39,12 @@ class ABC:
         # test satisfies
         (1, exp.Any(satisfies=lambda x: x % 2 == 0), False),
         (2, exp.Any(satisfies=lambda x: x % 2 == 0), True),
+        # test type
+        (1, exp.Any(type=float), False),
+        (2, exp.Any(type=int), True),
+        # test instance_of
+        (ABC(), exp.Any(instance_of=dict), False),
+        (ABC(), exp.Any(instance_of=object), True),
     ],
 )
 def test_any(value, expect, result):
@@ -75,6 +81,12 @@ def test_any(value, expect, result):
         # test satisfies
         (1, exp.AnyValue(satisfies=lambda x: x % 2 == 0), False),
         (2, exp.AnyValue(satisfies=lambda x: x % 2 == 0), True),
+        # test type
+        (1, exp.AnyValue(type=float), False),
+        (2, exp.AnyValue(type=int), True),
+        # test instance_of
+        (ABC(), exp.AnyValue(instance_of=dict), False),
+        (ABC(), exp.AnyValue(instance_of=object), True),
     ],
 )
 def test_any_value(value, expect, result):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,15 @@
+import expyct
+
+
+def test_instance_type_instanceof():
+    """Tests that the Instance matcher can pretend to be an instance of another class."""
+    instance = expyct.Instance(type=float)
+    assert instance.__class__ == float
+    assert isinstance(instance, float)
+
+
+def test_instance_instance_of_instanceof():
+    """Tests that the Instance matcher can pretend to be an instance of another class."""
+    instance = expyct.Instance(instance_of=float)
+    assert instance.__class__ == float
+    assert isinstance(instance, float)


### PR DESCRIPTION
Changes:
- Add `type` and `instance_of` methods parameters to `Any` class
- Make `Instance` override `__class__` in order to pretend to be another class